### PR TITLE
Add debt tracking CLI for gold and USD receivables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Altın ve USD Alacak Takip Programı
+
+`debt_tracker.py`, ihracat firmalarının müşterilerinden olan alacaklarını hem USD hem de gram has altın cinsinden takip etmelerini sağlayan basit bir komut satırı uygulamasıdır.
+
+## Özellikler
+
+- Müşteriler bazında USD veya "pure gold" (gram has altın) cinsinden borç/alacak kaydı ekleme
+- Günlük has altın USD fiyatını (1 gram altın için USD) saklama
+- USD cinsinden alacakları, kaydın yapıldığı gündeki has altın fiyatına göre gram altın karşılığına çevirme
+- Genel toplam ve müşteri bazında rapor oluşturma
+- Verileri `ledger.json` dosyasına kaydederek oturumlar arasında saklama
+
+## Kurulum
+
+Python 3.9+ sürümüne sahip olmanız yeterlidir. Ek bir bağımlılık gerekmemektedir.
+
+## Kullanım
+
+Programı başlatmak için terminalden aşağıdaki komutu çalıştırın:
+
+```bash
+python debt_tracker.py
+```
+
+Uygulama size menü üzerinden şu işlemleri yapma imkânı verir:
+
+1. **Has altın fiyatı ekle/güncelle:** Bir tarih için 1 gram has altının USD fiyatını girin.
+2. **Borç kaydı ekle:** Müşteri adı, tarih, para birimi (usd veya pure gold) ve tutarı girerek yeni bir borç kaydı oluşturun. Borç tarihi için altın fiyatı kayıtlı değilse program sizi fiyat girmeye yönlendirir.
+3. **Genel toplamları göster:** Tüm müşterilerin USD toplamı, pure gold toplamı ve USD borçlarının altın karşılığı ile genel toplamı (gram) görüntüler.
+4. **Müşteriye özel toplamları göster:** Belirli bir müşteri için aynı özetleri verir.
+5. **Kayıtlı borçları listele:** Tüm borçları veya belirlediğiniz müşteriye ait borçları listeler.
+6. **Kaydet ve çık:** Verileri `ledger.json` dosyasına kaydedip programdan çıkmanızı sağlar.
+
+## Veri Dosyası
+
+Program, çalışma dizininde `ledger.json` adlı bir dosya oluşturur ve verileri bu dosyada saklar. Dosya yapısı örneği:
+
+```json
+{
+  "gold_prices": {
+    "2024-09-21": "74.50"
+  },
+  "debts": [
+    {
+      "customer": "Acme Ltd",
+      "currency": "USD",
+      "amount": "10000",
+      "booking_date": "2024-09-21"
+    },
+    {
+      "customer": "Acme Ltd",
+      "currency": "PURE_GOLD",
+      "amount": "150.25",
+      "booking_date": "2024-09-22"
+    }
+  ]
+}
+```
+
+## Notlar
+
+- Fiyatlar ve tutarlar `Decimal` kullanılarak yüksek hassasiyetle saklanır.
+- USD borçlarının altın karşılığını hesaplayabilmek için ilgili tarihe ait has altın USD fiyatının girilmiş olması gerekir.
+- Menüdeki tüm metinler Türkçe olduğundan uygulamayı günlük operasyonlarınıza kolayca adapte edebilirsiniz.

--- a/debt_tracker.py
+++ b/debt_tracker.py
@@ -1,0 +1,261 @@
+"""İhracat firmalarının altın ve USD alacaklarını takip etmeye yarayan yardımcı program.
+
+Programın temel özellikleri:
+
+* Müşteriler bazında "pure gold" (gram has altın) ve USD cinsinden borç/alacak kayıt edebilirsiniz.
+* Her gün için geçerli has altın (gram) USD fiyatını saklayabilirsiniz.
+* USD cinsinden borçları, kayıtlı oldukları günün has altın USD fiyatıyla gram altın cinsine
+  dönüştürür ve toplamda müşteriye ait altın karşılığını hesaplar.
+* Veriler `ledger.json` dosyasında saklanır; böylece programdan çıktığınızda bilgileriniz korunur.
+
+Program etkileşimli bir menü ile çalışır ve tamamen Türkçe olarak tasarlanmıştır.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation, getcontext
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+# Ondalık işlemlerinde hassasiyet kaybı olmaması için yüksek bir hassasiyet tanımlıyoruz.
+getcontext().prec = 28
+
+
+DATA_FILE = Path("ledger.json")
+
+
+@dataclass
+class DebtEntry:
+    """Her bir müşteri borç kaydı için kullanılan veri yapısı."""
+
+    customer: str
+    currency: str  # "PURE_GOLD" veya "USD"
+    amount: Decimal
+    booking_date: date
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "customer": self.customer,
+            "currency": self.currency,
+            "amount": format(self.amount, "f"),
+            "booking_date": self.booking_date.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, str]) -> "DebtEntry":
+        return cls(
+            customer=data["customer"],
+            currency=data["currency"],
+            amount=Decimal(data["amount"]),
+            booking_date=datetime.strptime(data["booking_date"], "%Y-%m-%d").date(),
+        )
+
+
+class DebtLedger:
+    """Müşteri borçlarını ve günlük altın fiyatlarını yöneten sınıf."""
+
+    def __init__(self, data_file: Path = DATA_FILE) -> None:
+        self.data_file = data_file
+        self.gold_prices: Dict[date, Decimal] = {}
+        self.debts: List[DebtEntry] = []
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Veri yönetimi
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.data_file.exists():
+            return
+        with self.data_file.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        self.gold_prices = {
+            datetime.strptime(day, "%Y-%m-%d").date(): Decimal(value)
+            for day, value in raw.get("gold_prices", {}).items()
+        }
+        self.debts = [DebtEntry.from_dict(item) for item in raw.get("debts", [])]
+
+    def save(self) -> None:
+        payload = {
+            "gold_prices": {day.isoformat(): format(price, "f") for day, price in self.gold_prices.items()},
+            "debts": [entry.to_dict() for entry in self.debts],
+        }
+        with self.data_file.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+
+    # ------------------------------------------------------------------
+    # Altın fiyatı yönetimi
+    # ------------------------------------------------------------------
+    def set_gold_price(self, pricing_date: date, usd_price_per_gram: Decimal) -> None:
+        self.gold_prices[pricing_date] = usd_price_per_gram
+
+    def get_gold_price(self, pricing_date: date) -> Optional[Decimal]:
+        return self.gold_prices.get(pricing_date)
+
+    # ------------------------------------------------------------------
+    # Borç işlemleri
+    # ------------------------------------------------------------------
+    def add_debt(self, entry: DebtEntry) -> None:
+        if entry.currency not in {"PURE_GOLD", "USD"}:
+            raise ValueError("currency 'PURE_GOLD' veya 'USD' olmalıdır")
+        self.debts.append(entry)
+
+    def list_debts(self, customer: Optional[str] = None) -> Iterable[DebtEntry]:
+        for entry in self.debts:
+            if customer is None or entry.customer == customer:
+                yield entry
+
+    # ------------------------------------------------------------------
+    # Raporlama
+    # ------------------------------------------------------------------
+    def compute_totals(self, customer: Optional[str] = None) -> Dict[str, Decimal]:
+        usd_total = Decimal("0")
+        pure_gold_total = Decimal("0")
+        usd_as_gold_total = Decimal("0")
+
+        for entry in self.list_debts(customer):
+            if entry.currency == "USD":
+                usd_total += entry.amount
+                gold_price = self.get_gold_price(entry.booking_date)
+                if gold_price is None or gold_price == 0:
+                    raise ValueError(
+                        f"{entry.booking_date.isoformat()} tarihi için has altın USD fiyatı tanımlı değil"
+                    )
+                usd_as_gold_total += entry.amount / gold_price
+            else:
+                pure_gold_total += entry.amount
+
+        return {
+            "usd_total": usd_total,
+            "pure_gold_total": pure_gold_total,
+            "usd_as_gold_total": usd_as_gold_total,
+            "grand_total_gold": pure_gold_total + usd_as_gold_total,
+        }
+
+
+def prompt_date(message: str) -> date:
+    while True:
+        raw = input(message).strip()
+        try:
+            return datetime.strptime(raw, "%Y-%m-%d").date()
+        except ValueError:
+            print("Tarih formatı hatalı. Örnek kullanım: 2024-09-21")
+
+
+def prompt_decimal(message: str) -> Decimal:
+    while True:
+        raw = input(message).strip().replace(",", ".")
+        try:
+            return Decimal(raw)
+        except InvalidOperation:
+            print("Lütfen sayısal bir değer girin.")
+
+
+def prompt_currency() -> str:
+    while True:
+        raw = input("Para birimi (pure gold / usd): ").strip().upper()
+        if raw in {"PURE GOLD", "PURE_GOLD", "GOLD"}:
+            return "PURE_GOLD"
+        if raw in {"USD", "$"}:
+            return "USD"
+        print("Geçersiz para birimi. 'pure gold' veya 'usd' giriniz.")
+
+
+def render_totals(ledger: DebtLedger, customer: Optional[str] = None) -> None:
+    try:
+        totals = ledger.compute_totals(customer=customer)
+    except ValueError as exc:
+        print(f"Hata: {exc}")
+        return
+
+    header = "Tüm müşteriler" if customer is None else f"Müşteri: {customer}"
+    print("\n===", header, "===")
+    print(f"Toplam USD alacağı       : {totals['usd_total']:.2f} USD")
+    print(f"Toplam Pure Gold alacağı  : {totals['pure_gold_total']:.4f} gram")
+    print(f"USD alacakların altın karşılığı: {totals['usd_as_gold_total']:.4f} gram")
+    print(f"GENEL TOPLAM (altın)      : {totals['grand_total_gold']:.4f} gram\n")
+
+
+def list_debts(ledger: DebtLedger, customer: Optional[str] = None) -> None:
+    rows = list(ledger.list_debts(customer))
+    if not rows:
+        print("Kayıt bulunamadı.")
+        return
+    for entry in rows:
+        currency = "Pure Gold" if entry.currency == "PURE_GOLD" else "USD"
+        print(
+            f"{entry.booking_date.isoformat()} | {entry.customer:20} | "
+            f"{entry.amount:12.4f} {currency}"
+        )
+
+
+def ensure_price_for_date(ledger: DebtLedger, price_date: date) -> None:
+    if ledger.get_gold_price(price_date) is not None:
+        return
+    print(
+        f"{price_date.isoformat()} tarihi için has altın USD fiyatı bulunamadı."
+        " Lütfen fiyat giriniz."
+    )
+    price = prompt_decimal("Has altın USD fiyatı (1 gram için): ")
+    ledger.set_gold_price(price_date, price)
+
+
+def main() -> None:
+    ledger = DebtLedger()
+
+    MENU = {
+        "1": "Has altın fiyatı ekle/güncelle",
+        "2": "Borç kaydı ekle",
+        "3": "Genel toplamları göster",
+        "4": "Müşteriye özel toplamları göster",
+        "5": "Kayıtlı borçları listele",
+        "6": "Kaydet ve çık",
+    }
+
+    while True:
+        print("\n=== BORÇ TAKİP MENÜSÜ ===")
+        for key, label in MENU.items():
+            print(f"{key}. {label}")
+        choice = input("Seçiminiz: ").strip()
+
+        if choice == "1":
+            price_date = prompt_date("Fiyat tarihi (YYYY-AA-GG): ")
+            price = prompt_decimal("Has altın USD fiyatı (1 gram için): ")
+            ledger.set_gold_price(price_date, price)
+            ledger.save()
+            print("Fiyat kaydedildi.")
+        elif choice == "2":
+            customer = input("Müşteri adı: ").strip()
+            booking_date = prompt_date("Borç tarihi (YYYY-AA-GG): ")
+            ensure_price_for_date(ledger, booking_date)
+            currency = prompt_currency()
+            amount = prompt_decimal("Tutar: ")
+            entry = DebtEntry(
+                customer=customer,
+                currency=currency,
+                amount=amount,
+                booking_date=booking_date,
+            )
+            ledger.add_debt(entry)
+            ledger.save()
+            print("Borç kaydı başarıyla eklendi.")
+        elif choice == "3":
+            render_totals(ledger)
+        elif choice == "4":
+            customer = input("Müşteri adı: ").strip()
+            render_totals(ledger, customer=customer)
+        elif choice == "5":
+            customer_name = input("(Opsiyonel) Müşteri adı: ").strip() or None
+            list_debts(ledger, customer=customer_name)
+        elif choice == "6":
+            ledger.save()
+            print("Veriler kaydedildi. Program sonlandırılıyor.")
+            break
+        else:
+            print("Geçersiz seçim. Lütfen menüdeki seçeneklerden birini girin.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Turkish CLI tool to record receivables in USD and pure gold and convert USD debts to gold using daily prices
- persist gold prices and debt records in a JSON ledger for reuse between sessions
- document setup and usage details for the new workflow

## Testing
- python -m compileall debt_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a1efde2c832aa39a82d6d2fe14ca